### PR TITLE
`bgpFields` java.lang.ArrayIndexOutOfBoundsException: 13

### DIFF
--- a/src/main/java/vgiotsas/CommunitiesParser.java
+++ b/src/main/java/vgiotsas/CommunitiesParser.java
@@ -391,13 +391,12 @@ class CommunitiesParser implements Parser {
                     // For each community attached in the path that is part of the target communities provided by the
                     // user, find which AS link it annotates and inster the annotated BGP route in a HashMap that stores
                     // the annotated routes and the corresponding communities
-                    String[] attachedCommunities = bgpFields[13].split(" ");
+                    String[] attachedCommunities = bgpFields[11].split(" ");
                     String timestamp = bgpFields[2].split("\\.")[0];
-                    String peerIp = bgpFields[8];
-                    String prefix = bgpFields[9];
-
+                    String peerIp = bgpFields[6];
+                    String prefix = bgpFields[7];
                     for (String community: attachedCommunities) {
-                        ArrayList<String> path = removePrepending(bgpFields[11].split(" "));
+                        ArrayList<String> path = removePrepending(bgpFields[9].split(" "));
                         if (targetCommunities.contains(community)){
                             String top16bits = community.split(":")[0];
                             // if the top16 bits correspond to a Route Server ASN


### PR DESCRIPTION
I tried to run CommunitiesParser with the example mentioned in `README.md`

https://github.com/vgiotsas/CommunitiesParser/blob/7c3f447e3b65d1fef93c61d4f82b3695c8d3f8db/README.md#L69-L73

However with this example an `ArrayIndexOutOfBoundsException` rises:

````shell
$ java -cp ./resources:./src/main/java/:/usr/share/java/args4j.jar:/usr/share/java/json-simple.jar:/usr/share/java/commons-compress.jar vgiotsas/Main --outdir output --collectors rrc00 --communities 2914:1201 --period 20180407.0000,20180410.0000 --facilities "Interxion Frankfurt (FRA1-12)"
Couldn't reach URL https://www.euro-ix.net/csv/ixp-service-matrix
/usr/local/bin/bgpreader -w 1522965600,1523052000 -t ribs -P 86400 -c rrc00 -y 2914:1201
Exception in thread "main" java.lang.ArrayIndexOutOfBoundsException: 13
        at vgiotsas.CommunitiesParser.getAnnotatedPaths(CommunitiesParser.java:394)
        at vgiotsas.CommunitiesParser.startParser(CommunitiesParser.java:79)
        at vgiotsas.Main.main(Main.java:18)                                                                                                                         
java -cp  vgiotsas/Main --outdir output --collectors rrc00 --communities       5,38s user 0,63s system 25% cpu 23,833 total
````

I looked at the corresponding code and indeed the `bgpFields` array did have only 11 elements. Hover it did not look like as if `bgpFields` was malformed. All necessary fields did exist, they were just accessed at the wrong places. The PR will correct them accordingly.

But that probably do not solve the problem.
The if directly before the exception checks if the array has over 9 elements:
https://github.com/vgiotsas/CommunitiesParser/blob/7c3f447e3b65d1fef93c61d4f82b3695c8d3f8db/src/main/java/vgiotsas/CommunitiesParser.java#L390-L400

However, the original code also access 11 and 13, and the array I looked at (the PR) needs at least 11 elements. I am not sure what is expected here, so please check that (That means this PR is probably not useful at all, although I did not have any exception any more)

Checked with current master
bgpstream v 1.1.0 and v 1.2.0 both checked
java version "1.8.0_181" (TM) SE Runtime Environment (build 1.8.0_181-b13)

